### PR TITLE
'import to Deck' is fixed in version 26

### DIFF
--- a/appinfo/info.xml
+++ b/appinfo/info.xml
@@ -5,14 +5,14 @@
     <name>Deck Import From Trello</name>
     <summary>nextcloud app that allows Deck import from Trello export to JSON file</summary>
     <description><![CDATA[nextcloud app that allows Deck import from Trello export to JSON file]]></description>
-    <version>1.0.2</version>
+    <version>1.0.2wga</version>
     <licence>agpl</licence>
     <author mail="hello@newro.co" homepage="https://newro.co">newroco</author>
     <namespace>DeckImportFromTrello</namespace>
     <category>tools</category>
     <bugs>https://github.com/newroco/DeckImportFromTrello/issues</bugs>
     <dependencies>
-        <nextcloud min-version="18" max-version="24"/>
+        <nextcloud min-version="18" max-version="27"/>
     </dependencies>
     <settings>
         <personal>OCA\DeckImportFromTrello\Settings\Personal</personal>

--- a/js/deckimportfromtrello.js
+++ b/js/deckimportfromtrello.js
@@ -2,7 +2,7 @@
     var url = OC.generateUrl('/apps/deckimportfromtrello/');
 
     $(document).ready(function () {
-        if ($('#dir').length > 0) {
+        //if ($('#dir').length > 0) {
             OCA.Files.fileActions.registerAction({
                 name: 'deckimportfromtrello',
                 displayName: 'Import to Deck',
@@ -15,7 +15,7 @@
                     importFile(context.$file);
                 }
             });
-        }
+       // }
     });
 
     function importFile($file) {


### PR DESCRIPTION
in Nextcloud 26, I was faced with the fact that after installation according to the instructions, the "import to Deck" button does not appear.

I propose a solution to the problem.